### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: Documents Search CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/rubixvi/rubix-documents/security/code-scanning/3](https://github.com/rubixvi/rubix-documents/security/code-scanning/3)

To fix the problem, you should add a `permissions` block to the workflow to explicitly restrict the permissions granted to the GITHUB_TOKEN. The best way to do this is to add the block at the root level of the workflow file (above the `jobs:` key), so it applies to all jobs unless overridden. For this workflow, the minimal required permission is `contents: read`, which allows the workflow to read repository contents but not write to them. No additional permissions are needed for the steps shown. The change should be made in `.github/workflows/ci.yml`, by inserting the following block after the workflow name and before the `on:` key:

```yaml
permissions:
  contents: read
```

No imports or additional definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

CI:
- Restrict GITHUB_TOKEN permissions in CI workflow to contents: read to address code scanning alert