### PR TITLE
fix: update node engine version specification to allow minor updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "typescript-eslint": "^8.49.0"
   },
   "engines": {
-    "node": "22.x"
+    "node": "^22.x"
   },
   "packageManager": "pnpm@10.25.0"
 }


### PR DESCRIPTION
This pull request makes a minor update to the `package.json` file by changing the Node.js engine requirement to allow any compatible version within the 22.x range, rather than requiring exactly version 22.x.