### PR TITLE
Use pnpm rather than npm in the 'continuous integration' github action.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,20 +15,25 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        node-version: [20]
+
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v3
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
         with:
-          node-version: "20" # Updated to Node.js 20 as per the GitHub Actions change
-
+          node-version: ${{ matrix.node-version }}
+          cache: "pnpm"
       - name: Install dependencies
-        run: npm install
+        run: pnpm install
 
       - name: Compile TypeScript
-        run: npx tsc --project tsconfig.scripts.json
+        run: pnpm tsc --project tsconfig.scripts.json
 
       - name: Rename .js files to .mjs
         run: |


### PR DESCRIPTION
Use pnpm rather than npm in the 'continuous integration' github action. 

The motivation is to provide symmetry with the local development environment. For example, the README.md specifies using pnpm so the pipeline should also use it.

I used this documentation https://pnpm.io/continuous-integration#github-actions as a guide.

## Summary by Sourcery

Switch the continuous integration workflow to use pnpm for Node.js builds with an updated GitHub Actions configuration.

CI:
- Update the CI workflow to install and use pnpm instead of npm for dependency installation and TypeScript compilation.
- Introduce a Node.js version matrix (currently Node 20) with setup-node v4 and pnpm caching, and bump checkout to v4.