### PR TITLE
chore: update build script to increase memory limit for next build

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "next dev --turbopack",
-    "build": "next build",
+    "build": "NODE_OPTIONS='--max-old-space-size=6144' next build",
     "start": "next start",
     "clean": "pnpm biome check --write",
     "update": "pnpm update --latest --recursive && pnpm install && pnpm prune && pnpm dedupe && pnpm run clean",


### PR DESCRIPTION
This pull request makes a single configuration change to the build process. The `build` script in `package.json` now sets a higher memory limit for Node.js during the build, which can help prevent out-of-memory errors when building large Next.js projects.

- Increased Node.js memory allocation to 6GB in the `build` script by setting `NODE_OPTIONS='--max-old-space-size=6144'` in `package.json`.